### PR TITLE
APPS HTTP server: trace requests and responses, clean up logging

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2682,7 +2682,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
         msgs++;
         if (req != NULL) {
             if (strcmp(path, "") != 0 && strcmp(path, "pkix/") != 0) {
-                (void)http_server_send_status(cbio, 404, "Not Found");
+                (void)http_server_send_status(prog, cbio, 404, "Not Found");
                 CMP_err1("expecting empty path or 'pkix/' but got '%s'",
                          path);
                 OPENSSL_free(path);
@@ -2693,11 +2693,11 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
             resp = OSSL_CMP_CTX_server_perform(cmp_ctx, req);
             OSSL_CMP_MSG_free(req);
             if (resp == NULL) {
-                (void)http_server_send_status(cbio,
+                (void)http_server_send_status(prog, cbio,
                                               500, "Internal Server Error");
                 break; /* treated as fatal error */
             }
-            ret = http_server_send_asn1_resp(cbio, keep_alive,
+            ret = http_server_send_asn1_resp(prog, cbio, keep_alive,
                                              "application/pkixcmp",
                                              ASN1_ITEM_rptr(OSSL_CMP_MSG),
                                              (const ASN1_VALUE *)resp);

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -11,6 +11,7 @@
 # define OSSL_HTTP_SERVER_H
 
 # include "apps.h"
+# include "log.h"
 
 # ifndef HAVE_FORK
 #  if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
@@ -31,36 +32,9 @@
 #  define HTTP_DAEMON
 #  include <sys/types.h>
 #  include <sys/wait.h>
-#  include <syslog.h>
 #  include <signal.h>
 #  define MAXERRLEN 1000 /* limit error text sent to syslog to 1000 bytes */
 # endif
-
-# undef LOG_TRACE
-# undef LOG_DEBUG
-# undef LOG_INFO
-# undef LOG_WARNING
-# undef LOG_ERR
-# define LOG_TRACE     8
-# define LOG_DEBUG     7
-# define LOG_INFO      6
-# define LOG_WARNING   4
-# define LOG_ERR       3
-
-/*-
- * Output a message using the trace API with the given category
- * if the category is >= 0 and tracing is enabled.
- * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
- * if the verbosity is sufficient for the given level of severity.
- * category: trace category as defined in trace.h, or -1
- * prog: the name of the current app, or NULL
- * level: the severity of the message, e.g., LOG_ERR
- * fmt: message format, which should not include a trailing newline
- * ...: potential extra parameters like with printf()
- * returns nothing
- */
-void trace_log_message(int category,
-                       const char *prog, int level, const char *fmt, ...);
 
 # ifndef OPENSSL_NO_SOCK
 /*-

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -48,13 +48,19 @@
 # define LOG_ERR       3
 
 /*-
- * Log a message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
- * prog: the name of the current app
+ * Output a message using the trace API with the given category
+ * if the category is >= 0 and tracing is enabled.
+ * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
+ * if the verbosity is sufficient for the given level of severity.
+ * category: trace category as defined in trace.h, or -1
+ * prog: the name of the current app, or NULL
  * level: the severity of the message, e.g., LOG_ERR
- * fmt: message with potential extra parameters like with printf()
+ * fmt: message format, which should not include a trailing newline
+ * ...: potential extra parameters like with printf()
  * returns nothing
  */
-void log_message(const char *prog, int level, const char *fmt, ...);
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...);
 
 # ifndef OPENSSL_NO_SOCK
 /*-
@@ -92,6 +98,7 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
 
 /*-
  * Send an ASN.1-formatted HTTP response
+ * prog: the name of the current app, for diagnostics only
  * cbio: destination BIO (typically as returned by http_server_get_asn1_req())
  *       note: cbio should not do an encoding that changes the output length
  * keep_alive: grant persistent connection
@@ -100,18 +107,20 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
  * resp: the response to send
  * returns 1 on success, 0 on failure
  */
-int http_server_send_asn1_resp(BIO *cbio, int keep_alive,
+int http_server_send_asn1_resp(const char *prog, BIO *cbio, int keep_alive,
                                const char *content_type,
                                const ASN1_ITEM *it, const ASN1_VALUE *resp);
 
 /*-
  * Send a trivial HTTP response, typically to report an error or OK
+ * prog: the name of the current app, for diagnostics only
  * cbio: destination BIO (typically as returned by http_server_get_asn1_req())
  * status: the status code to send
  * reason: the corresponding human-readable string
  * returns 1 on success, 0 on failure
  */
-int http_server_send_status(BIO *cbio, int status, const char *reason);
+int http_server_send_status(const char *prog, BIO *cbio,
+                            int status, const char *reason);
 
 # endif
 

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -125,7 +125,7 @@ int http_server_send_status(const char *prog, BIO *cbio,
 # endif
 
 # ifdef HTTP_DAEMON
-extern int multi;
+extern int n_responders;
 extern int acfd;
 
 void socket_timeout(int signum);

--- a/apps/include/log.h
+++ b/apps/include/log.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APPS_LOG_H
+# define OSSL_APPS_LOG_H
+
+# include <openssl/bio.h>
+# if !defined(OPENSSL_SYS_VMS) && !defined(OPENSSL_SYS_WINDOWS) \
+    && !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_POSIX_IO)
+#  include <syslog.h>
+# else
+#  define LOG_EMERG   0
+#  define LOG_ALERT   1
+#  define LOG_CRIT    2
+#  define LOG_ERR     3
+#  define LOG_WARNING 4
+#  define LOG_NOTICE  5
+#  define LOG_INFO    6
+#  define LOG_DEBUG   7
+# endif
+
+# undef LOG_TRACE
+# define LOG_TRACE (LOG_DEBUG + 1)
+
+int log_set_verbosity(const char *prog, int level);
+int log_get_verbosity(void);
+
+/*-
+ * Output a message using the trace API with the given category
+ * if the category is >= 0 and tracing is enabled.
+ * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
+ * if the verbosity is sufficient for the given level of severity.
+ * Yet cannot do both types of output in strict ANSI mode.
+ * category: trace category as defined in trace.h, or -1
+ * prog: the name of the current app, or NULL
+ * level: the severity of the message, e.g., LOG_ERR
+ * fmt: message format, which should not include a trailing newline
+ * ...: potential extra parameters like with printf()
+ * returns nothing
+ */
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...);
+
+#endif /* OSSL_APPS_LOG_H */

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -8,7 +8,7 @@ IF[{- $config{target} =~ /^vms-/ -}]
 ENDIF
 
 # Source for libapps
-$LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
+$LIBAPPSSRC=apps.c apps_ui.c log.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
         engine.c engine_loader.c app_libctx.c apps_opt_printf.c
 

--- a/apps/lib/log.c
+++ b/apps/lib/log.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/trace.h>
+#include "apps.h"
+#include "log.h"
+
+static int verbosity = LOG_INFO;
+
+int log_set_verbosity(const char *prog, int level)
+{
+    if (level < LOG_EMERG || level > LOG_TRACE) {
+        trace_log_message(-1, prog, LOG_ERR,
+                          "Invalid verbosity level %d", level);
+        return 0;
+    }
+    verbosity = level;
+    return 1;
+}
+
+int log_get_verbosity(void)
+{
+    return verbosity;
+}
+
+#ifdef HTTP_DAEMON
+static int print_syslog(const char *str, size_t len, void *levPtr)
+{
+    int level = *(int *)levPtr;
+    int ilen = len > MAXERRLEN ? MAXERRLEN : len;
+
+    syslog(level, "%.*s", ilen, str);
+
+    return ilen;
+}
+#endif
+
+static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
+{
+    char prefix[80];
+    BIO *bio, *pre = BIO_new(BIO_f_prefix());
+
+    (void)snprintf(prefix, sizeof(prefix), "%s: ", prog);
+    (void)BIO_set_prefix(pre, prefix);
+    bio = BIO_push(pre, bio_err);
+    (void)BIO_vprintf(bio, fmt, ap);
+    (void)BIO_printf(bio, "\n");
+    (void)BIO_flush(bio);
+    (void)BIO_pop(pre);
+    BIO_free(pre);
+}
+
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+#ifdef __STRICT_ANSI__ /* unfortuantely, ANSI does not define va_copy */
+    if (verbosity >= level)
+        category = -1; /* disabling trace output in addition to logging */
+#endif
+    if (category >= 0 && OSSL_trace_enabled(category)) {
+        BIO *out = OSSL_trace_begin(category);
+#ifndef __STRICT_ANSI__
+        va_list ap_copy;
+
+        va_copy(ap_copy, ap);
+        (void)BIO_vprintf(out, fmt, ap_copy);
+        va_end(ap_copy);
+#else
+        (void)BIO_vprintf(out, fmt, ap);
+#endif
+        (void)BIO_printf(out, "\n");
+        OSSL_trace_end(category, out);
+    }
+    if (verbosity < level) {
+        va_end(ap);
+        return;
+    }
+#ifdef HTTP_DAEMON
+    if (n_responders != 0) {
+        vsyslog(level, fmt, ap);
+        if (level <= LOG_ERR)
+            ERR_print_errors_cb(print_syslog, &level);
+    } else
+#endif
+    log_with_prefix(prog, fmt, ap);
+    va_end(ap);
+}

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -529,7 +529,7 @@ int ocsp_main(int argc, char **argv)
             break;
         case OPT_MULTI:
 #ifdef HTTP_DAEMON
-            multi = atoi(opt_arg());
+            n_responders = atoi(opt_arg());
 #endif
             break;
         case OPT_PROV_CASES:
@@ -633,7 +633,7 @@ int ocsp_main(int argc, char **argv)
     }
 
 #ifdef HTTP_DAEMON
-    if (multi != 0 && acbio != NULL)
+    if (n_responders != 0 && acbio != NULL)
         spawn_loop(prog);
     if (acbio != NULL && req_timeout > 0)
         signal(SIGALRM, socket_timeout);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -633,14 +633,15 @@ int ocsp_main(int argc, char **argv)
     }
 
 #ifdef HTTP_DAEMON
-    if (multi && acbio != NULL)
+    if (multi != 0 && acbio != NULL)
         spawn_loop(prog);
     if (acbio != NULL && req_timeout > 0)
         signal(SIGALRM, socket_timeout);
 #endif
 
     if (acbio != NULL)
-        log_message(prog, LOG_INFO, "waiting for OCSP client connections...");
+        trace_log_message(-1, prog,
+                          LOG_INFO, "waiting for OCSP client connections...");
 
 redo_accept:
 
@@ -654,8 +655,9 @@ redo_accept:
                 rdb = newrdb;
             } else {
                 free_index(newrdb);
-                log_message(prog, LOG_ERR, "error reloading updated index: %s",
-                            ridx_filename);
+                trace_log_message(-1, prog,
+                                  LOG_ERR, "error reloading updated index: %s",
+                                  ridx_filename);
             }
         }
 #endif
@@ -1217,7 +1219,7 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
 static int send_ocsp_response(BIO *cbio, const OCSP_RESPONSE *resp)
 {
 #ifndef OPENSSL_NO_SOCK
-    return http_server_send_asn1_resp(cbio,
+    return http_server_send_asn1_resp(prog, cbio,
                                       0 /* no keep-alive */,
                                       "application/ocsp-response",
                                       ASN1_ITEM_rptr(OCSP_RESPONSE),

--- a/crypto/bio/bf_readbuff.c
+++ b/crypto/bio/bf_readbuff.c
@@ -201,6 +201,13 @@ static long readbuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_FLUSH:
         ret = 1;
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -547,6 +547,13 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
         else
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -592,6 +592,12 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
         }
         break;
 
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
     }

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -601,6 +601,13 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
 # endif
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -792,6 +792,13 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_SET_PEEK_MODE:
         data->peekmode = (unsigned int)num;
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -189,6 +189,13 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_EOF:
         ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -333,6 +333,12 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 1;
         break;
 
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     case BIO_CTRL_WPENDING:
     case BIO_CTRL_PENDING:
     case BIO_CTRL_PUSH:

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -329,6 +329,13 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_FLUSH:
         ret = 1;
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     case BIO_CTRL_PUSH:
     case BIO_CTRL_POP:
     default:

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -60,6 +60,13 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DUP:
         ret = 1;
         break;
+
+    case BIO_CTRL_SET_PREFIX:
+    case BIO_CTRL_SET_INDENT:
+    case BIO_CTRL_GET_INDENT:
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+
     case BIO_CTRL_GET_CLOSE:
     case BIO_CTRL_INFO:
     case BIO_CTRL_GET:

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -20,6 +20,7 @@
 #include <openssl/cmperr.h>
 #include <openssl/buffer.h>
 #include <openssl/http.h>
+#include <openssl/trace.h>
 #include "internal/sockets.h"
 #include "internal/common.h" /* for ossl_assert() */
 
@@ -485,6 +486,7 @@ static int may_still_retry(time_t max_time, int *ptimeout)
 int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
 {
     int i, found_expected_ct = 0, found_keep_alive = 0;
+    int found_text_ct = 0;
     long n;
     size_t resp_len;
     const unsigned char *p;
@@ -540,6 +542,8 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
     case OHS_WRITE_INIT:
         rctx->len_to_send = BIO_get_mem_data(rctx->mem, &rctx->pos);
         rctx->state = OHS_WRITE_HDR;
+        if (OSSL_TRACE_ENABLED(HTTP))
+            OSSL_TRACE(HTTP, "Sending request header:\n");
 
         /* fall thru */
     case OHS_WRITE_HDR:
@@ -548,6 +552,10 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
         /* Copy some chunk of data from rctx->req to rctx->wbio */
 
         if (rctx->len_to_send > 0) {
+            if (OSSL_TRACE_ENABLED(HTTP)
+                && rctx->state == OHS_WRITE_HDR && rctx->len_to_send <= INT_MAX)
+                OSSL_TRACE2(HTTP, "%.*s", (int)rctx->len_to_send, rctx->pos);
+
             i = BIO_write(rctx->wbio, rctx->pos, rctx->len_to_send);
             if (i <= 0) {
                 if (BIO_should_retry(rctx->wbio))
@@ -631,6 +639,13 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             return 0;
         }
 
+        /* dump all response header lines */
+        if (OSSL_TRACE_ENABLED(HTTP)) {
+            if (rctx->state == OHS_FIRSTLINE)
+                OSSL_TRACE(HTTP, "Received response header:\n");
+            OSSL_TRACE1(HTTP, "%s", buf);
+        }
+
         /* First line */
         if (rctx->state == OHS_FIRSTLINE) {
             switch (parse_http_line1(buf, &found_keep_alive)) {
@@ -669,15 +684,20 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
                 rctx->redirection_url = value;
                 return 0;
             }
-            if (rctx->state == OHS_HEADERS && rctx->expected_ct != NULL
-                    && OPENSSL_strcasecmp(key, "Content-Type") == 0) {
-                if (OPENSSL_strcasecmp(rctx->expected_ct, value) != 0) {
-                    ERR_raise_data(ERR_LIB_HTTP, HTTP_R_UNEXPECTED_CONTENT_TYPE,
-                                   "expected=%s, actual=%s",
-                                   rctx->expected_ct, value);
-                    return 0;
+            if (OPENSSL_strcasecmp(key, "Content-Type") == 0) {
+                if (rctx->state == OHS_HEADERS
+                    && rctx->expected_ct != NULL) {
+                    if (OPENSSL_strcasecmp(rctx->expected_ct, value) != 0) {
+                        ERR_raise_data(ERR_LIB_HTTP,
+                                       HTTP_R_UNEXPECTED_CONTENT_TYPE,
+                                       "expected=%s, actual=%s",
+                                       rctx->expected_ct, value);
+                        return 0;
+                    }
+                    found_expected_ct = 1;
                 }
-                found_expected_ct = 1;
+                if (OPENSSL_strncasecmp(value, "text/", 5) == 0)
+                    found_text_ct = 1;
             }
 
             /* https://tools.ietf.org/html/rfc7230#section-6.3 Persistence */
@@ -717,8 +737,12 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             rctx->keep_alive = 0;
         }
 
-        if (rctx->state == OHS_ERROR)
+        if (rctx->state == OHS_ERROR) {
+            if (OSSL_TRACE_ENABLED(HTTP)
+                    && found_text_ct && BIO_get_mem_data(rctx->mem, &p) > 0)
+                OSSL_TRACE1(HTTP, "%s", p);
             return 0;
+        }
 
         if (rctx->expected_ct != NULL && !found_expected_ct) {
             ERR_raise_data(ERR_LIB_HTTP, HTTP_R_MISSING_CONTENT_TYPE,

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -138,8 +138,9 @@ static const struct trace_category_st trace_categories[] = {
     TRACE_CATEGORY_(STORE),
     TRACE_CATEGORY_(DECODER),
     TRACE_CATEGORY_(ENCODER),
-    TRACE_CATEGORY_(REF_COUNT)
-};
+    TRACE_CATEGORY_(REF_COUNT),
+    TRACE_CATEGORY_(HTTP),
+}; /* KEEP THIS LIST IN SYNC with #define OSSL_TRACE_CATEGORY_... in trace.h */
 
 const char *OSSL_trace_get_category_name(int num)
 {

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -1060,6 +1060,10 @@ although they usually contain hints that would be helpful for diagnostics.
 For assisting in such cases the CMP client offers a workaround via the
 B<-unprotected_errors> option, which allows accepting such negative messages.
 
+If OpenSSL was built with trace support enabled
+and the environment variable B<OPENSSL_TRACE> includes B<HTTP>,
+the request and response headers of HTTP transfers are printed.
+
 =head1 EXAMPLES
 
 =head2 Simple examples using the default OpenSSL configuration file

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -710,8 +710,8 @@ see L<openssl-env(7)>.
 
 Enable tracing output of OpenSSL library, by name.
 This output will only make sense if you know OpenSSL internals well.
-Also, it might not give you any output at all, depending on how
-OpenSSL was built.
+Also, it might not give you any output at all
+if OpenSSL was built without tracing support.
 
 The value is a comma separated list of names, with the following
 available:
@@ -765,6 +765,10 @@ policy evaluation.
 =item B<BN_CTX>
 
 BIGNUM context.
+
+=item B<HTTP>
+
+HTTP client diagnostics
 
 =back
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -768,7 +768,7 @@ BIGNUM context.
 
 =item B<HTTP>
 
-HTTP client diagnostics
+HTTP client and server diagnostics
 
 =back
 

--- a/doc/man3/BIO_f_prefix.pod
+++ b/doc/man3/BIO_f_prefix.pod
@@ -46,10 +46,10 @@ implemented as macros.
 
 BIO_f_prefix() returns the prefix BIO method.
 
-BIO_set_prefix() returns 1 if the prefix was correctly set, or <=0 on
+BIO_set_prefix() returns 1 if the prefix was correctly set, or <= 0 on
 failure.
 
-BIO_set_indent() returns 1 if the prefix was correctly set, or <=0 on
+BIO_set_indent() returns 1 if the prefix was correctly set, or <= 0 on
 failure.
 
 BIO_get_indent() returns the current indentation, or a negative value for failure.

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -213,6 +213,13 @@ This may be omitted if the GET method is used and "keep-alive" is not requested.
 When the request context is fully prepared, the HTTP exchange may be performed
 with OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_exchange().
 
+=head1 NOTES
+
+When built with tracing enabled, OSSL_HTTP_REQ_CTX_nbio() and all functions
+using it, such as OSSL_HTTP_REQ_CTX_exchange() and L<OSSL_HTTP_transfer(3)>,
+may be traced using B<OSSL_TRACE_CATEGORY_HTTP>.
+See also L<OSSL_trace_enabled(3)> and L<openssl(1)/ENVIRONMENT>.
+
 =head1 RETURN VALUES
 
 OSSL_HTTP_REQ_CTX_new() returns a pointer to a B<OSSL_HTTP_REQ_CTX>, or NULL
@@ -248,7 +255,8 @@ L<ASN1_item_i2d_mem_bio(3)>,
 L<OSSL_HTTP_open(3)>,
 L<OSSL_HTTP_get(3)>,
 L<OSSL_HTTP_transfer(3)>,
-L<OSSL_HTTP_close(3)>
+L<OSSL_HTTP_close(3)>,
+L<OSSL_trace_enabled(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -245,6 +245,10 @@ C<http_proxy>, C<HTTP_PROXY>, C<https_proxy>, C<HTTPS_PROXY>, C<no_proxy>, and
 C<NO_PROXY>, have been chosen for maximal compatibility with
 other HTTP client implementations such as wget, curl, and git.
 
+When built with tracing enabled, OSSL_HTTP_transfer() and all functions using it
+may be traced using B<OSSL_TRACE_CATEGORY_HTTP>.
+See also L<OSSL_trace_enabled(3)> and L<openssl(1)/ENVIRONMENT>.
+
 =head1 RETURN VALUES
 
 OSSL_HTTP_open() returns on success a B<OSSL_HTTP_REQ_CTX>, else NULL.
@@ -266,7 +270,8 @@ OSSL_HTTP_close() returns 0 if anything went wrong while disconnecting, else 1.
 
 L<OSSL_HTTP_parse_url(3)>, L<BIO_new_connect(3)>,
 L<ASN1_item_i2d_mem_bio(3)>, L<ASN1_item_d2i_bio(3)>,
-L<OSSL_HTTP_is_alive(3)>
+L<OSSL_HTTP_is_alive(3)>,
+L<OSSL_trace_enabled(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -49,8 +49,8 @@ The functions described here are mainly interesting for those who provide
 OpenSSL functionality, either in OpenSSL itself or in engine modules
 or similar.
 
-If tracing is enabled (see L</NOTES> below), these functions are used to
-generate free text tracing output.
+If the tracing facility is enabled (see L</Configure Tracing> below),
+these functions are used to generate free text tracing output.
 
 The tracing output is divided into types which are enabled
 individually by the application.
@@ -59,13 +59,13 @@ L<OSSL_trace_set_callback(3)/Trace types>.
 The fallback type B<OSSL_TRACE_CATEGORY_ALL> should I<not> be used
 with the functions described here.
 
-Tracing for a specific category is enabled if a so called
+Tracing for a specific category is enabled at run-time if a so-called
 I<trace channel> is attached to it. A trace channel is simply a
 BIO object to which the application can write its trace output.
 
 The application has two different ways of registering a trace channel,
-either by directly providing a BIO object using OSSL_trace_set_channel(),
-or by providing a callback routine using OSSL_trace_set_callback().
+either by directly providing a BIO object using L<OSSL_trace_set_channel(3)>,
+or by providing a callback routine using L<OSSL_trace_set_callback(3)>.
 The latter is wrapped internally by a dedicated BIO object, so for the
 tracing code both channel types are effectively indistinguishable.
 We call them a I<simple trace channel> and a I<callback trace channel>,
@@ -86,7 +86,9 @@ but rather uses a set of convenience macros, see the L</Macros> section below.
 =head2 Functions
 
 OSSL_trace_enabled() can be used to check if tracing for the given
-I<category> is enabled.
+I<category> is enabled, i.e., if the tracing facility has been statically
+enabled (see L</Configure Tracing> below) and a trace channel has been
+registered using L<OSSL_trace_set_channel(3)> or L<OSSL_trace_set_callback(3)>.
 
 OSSL_trace_begin() is used to starts a tracing section, and get the
 channel for the given I<category> in form of a BIO.
@@ -109,7 +111,7 @@ used as follows to wrap a trace section:
 
  OSSL_TRACE_BEGIN(TLS) {
 
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -119,7 +121,7 @@ This will normally expand to:
      BIO *trc_out = OSSL_trace_begin(OSSL_TRACE_CATEGORY_TLS);
      if (trc_out != NULL) {
          ...
-         BIO_fprintf(trc_out, ...);
+         BIO_printf(trc_out, ...);
      }
      OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
  } while (0);
@@ -133,7 +135,7 @@ trace section:
          OSSL_TRACE_CANCEL(TLS);
          goto err;
      }
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -146,7 +148,7 @@ This will normally expand to:
              OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
              goto err;
          }
-         BIO_fprintf(trc_out, ... );
+         BIO_printf(trc_out, ... );
      }
      OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
  } while (0);
@@ -249,7 +251,7 @@ For example, take this example from L</Macros> section above:
          OSSL_TRACE_CANCEL(TLS);
          goto err;
      }
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -262,7 +264,7 @@ When the tracing API isn't operational, that will expand to:
              ((void)0);
              goto err;
          }
-         BIO_fprintf(trc_out, ... );
+         BIO_printf(trc_out, ... );
      }
  } while (0);
 
@@ -275,6 +277,10 @@ operational and enabled, otherwise 0.
 
 OSSL_trace_begin() returns a B<BIO> pointer if the given I<type> is enabled,
 otherwise NULL.
+
+=head1 SEE ALSO
+
+L<OSSL_trace_set_channel(3)>, L<OSSL_trace_set_callback(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -33,6 +33,7 @@ OSSL_TRACE_ENABLED
  } OSSL_TRACE_END(category);
 
  /* one-shot trace macros */
+ OSSL_TRACE(category, text)
  OSSL_TRACE1(category, format, arg1)
  OSSL_TRACE2(category, format, arg1, arg2)
  ...

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -21,13 +21,13 @@ OSSL_trace_set_callback, OSSL_trace_cb - Enabling trace output
 
 =head1 DESCRIPTION
 
-If available (see L</NOTES> below), the application can request
+If available (see L</Configure Tracing> below), the application can request
 internal trace output.
 This output comes in form of free text for humans to read.
 
 The trace output is divided into categories which can be
 enabled individually.
-Every category can be enabled individually by attaching a so called
+Every category can be enabled individually by attaching a so-called
 I<trace channel> to it, which in the simplest case is just a BIO object
 to which the application can write the tracing output for this category.
 Alternatively, the application can provide a tracer callback in order to
@@ -37,6 +37,11 @@ internally by a dedicated BIO object.
 For the tracing code, both trace channel types are indistinguishable.
 These are called a I<simple trace channel> and a I<callback trace channel>,
 respectively.
+
+L<OSSL_TRACE_ENABLED(3)> can be used to check whether tracing is currently
+enabled for the given category.
+Functions like L<OSSL_TRACE1(3)> and macros like L<OSSL_TRACE_BEGIN(3)>
+can be used for producing free-text trace output.
 
 =head2 Functions
 
@@ -56,7 +61,7 @@ OSSL_trace_set_callback() is used to enable the given trace
 I<category> by giving it the tracer callback I<cb> with the associated
 data I<data>, which will simply be passed through to I<cb> whenever
 it's called. The callback function is internally wrapped by a
-dedicated BIO object, the so called I<callback trace channel>.
+dedicated BIO object, the so-called I<callback trace channel>.
 This should be used when it's desirable to do form the trace output to
 something suitable for application needs where a prefix and suffix
 line aren't enough.
@@ -291,6 +296,11 @@ necessary to configure and build OpenSSL with the 'enable-trace' option.
 When the library is built with tracing disabled, the macro
 B<OPENSSL_NO_TRACE> is defined in F<< <openssl/opensslconf.h> >> and all
 functions described here are inoperational, i.e. will do nothing.
+
+=head1 SEE ALSO
+
+L<OSSL_TRACE_ENABLED(3)>, L<OSSL_TRACE_BEGIN(3)>, L<OSSL_TRACE1(3)>,
+L<atexit(3)>
 
 =head1 HISTORY
 

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -57,8 +57,10 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_DECODER            15
 # define OSSL_TRACE_CATEGORY_ENCODER            16
 # define OSSL_TRACE_CATEGORY_REF_COUNT          17
+# define OSSL_TRACE_CATEGORY_HTTP               18
 /* Count of available categories. */
-# define OSSL_TRACE_CATEGORY_NUM                18
+# define OSSL_TRACE_CATEGORY_NUM                19
+/* KEEP THIS LIST IN SYNC with trace_categories[] in crypto/trace.c */
 
 /* Returns the trace category number for the given |name| */
 int OSSL_trace_get_category_num(const char *name);

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -7,9 +7,21 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Unfortunate workaround to avoid symbol conflict with wincrypt.h
+ * See https://github.com/openssl/openssl/issues/9981
+ */
+#ifdef _WIN32
+# define WINCRYPT_USE_SYMBOL_PREFIX
+# undef X509_NAME
+# undef X509_EXTENSIONS
+# undef PKCS7_SIGNER_INFO
+# undef OCSP_REQUEST
+# undef OCSP_RESPONSE
+#endif
+
 #ifndef OPENSSL_TYPES_H
 # define OPENSSL_TYPES_H
-# pragma once
 
 # include <limits.h>
 
@@ -69,15 +81,6 @@ typedef struct asn1_string_table_st ASN1_STRING_TABLE;
 typedef struct ASN1_ITEM_st ASN1_ITEM;
 typedef struct asn1_pctx_st ASN1_PCTX;
 typedef struct asn1_sctx_st ASN1_SCTX;
-
-# ifdef _WIN32
-#  undef X509_NAME
-#  undef X509_EXTENSIONS
-#  undef PKCS7_ISSUER_AND_SERIAL
-#  undef PKCS7_SIGNER_INFO
-#  undef OCSP_REQUEST
-#  undef OCSP_RESPONSE
-# endif
 
 # ifdef BIGNUM
 #  undef BIGNUM

--- a/test/build.info
+++ b/test/build.info
@@ -58,7 +58,7 @@ IF[{- !$disabled{tests} -}]
           recordlentest drbgtest rand_status_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           http_test servername_test ocspapitest fatalerrtest tls13ccstest \
-          sysdefaulttest errtest ssl_ctx_test \
+          sysdefaulttest errtest ssl_ctx_test build_wincrypt_test \
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
@@ -929,6 +929,10 @@ ENDIF
   SOURCE[ssl_ctx_test]=ssl_ctx_test.c
   INCLUDE[ssl_ctx_test]=../include ../apps/include
   DEPEND[ssl_ctx_test]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[build_wincrypt_test]=build_wincrypt_test.c
+  INCLUDE[build_wincrypt_test]=../include
+  DEPEND[build_wincrypt_test]=../libssl ../libcrypto
 
 {-
    use File::Spec::Functions;

--- a/test/build_wincrypt_test.c
+++ b/test/build_wincrypt_test.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Simple buildtest to check for symbol collisions between wincrypt and
+ * OpenSSL headers
+ */
+
+#include <openssl/types.h>
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# include <wincrypt.h>
+# ifndef X509_NAME
+#  ifndef PEDANTIC
+#   warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#  endif
+# endif
+#endif
+
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_NO_STDIO
+# include <stdio.h>
+#endif
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
This preliminary PR depends on #18386.

* APPS HTTP server: trace requests and responses when enabled
* `apps/lib/http_server.{c,h}`: clean up logging and move it to `log.{c,h}`
* `OSSL_trace_enabled.pod`: add missing synopsis for `OSSL_TRACE()`
* `apps/ocsp.c` etc.: rename 'multi' to 'n_responders' for clarity
* `BIO_f_prefix`: improve diagnostics where not implemented; fix nit in doc
